### PR TITLE
Fix/style specificity, add icons

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -15,16 +15,16 @@
       }
     },
     "@aics/web-3d-viewer": {
-      "version": "2.3.3-dev.0",
-      "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.3.3-dev.0.tgz",
-      "integrity": "sha512-ruNRkjUDPnMO04N6m/d5JO6XRs80ga3tSqz6jaMD4EQ7MQcZaDlZFbU08kpqa2UMBvJuBa3ADeMGfLtWJmHtvw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.3.3.tgz",
+      "integrity": "sha512-uxNBJWtgztYAYBfrzEn78dFH6yrU6HvTbN2XX1Lv0xjajdKfOPgLZ/Io7QtzsRfG+r1aLIWTyyBOOIU32DpBkg==",
       "requires": {
         "@aics/volume-viewer": "^2.6.0",
         "color-string": "^1.5.3",
         "d3": "^4.11.0",
         "lodash": "^4.17.20",
         "nouislider-react": "^3.4.0",
-        "react-color": "^2.13.8"
+        "react-color": "^2.19.3"
       }
     },
     "@ampproject/remapping": {

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aics/volume-viewer": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-2.5.1.tgz",
-      "integrity": "sha512-i90xdc8/iGeByAklr37wqvs4kG2AWf2PU6Qxah8wkdK8+G8z/J/FUWS33K4ECZV4UrTntKu6ajqXI5K9qbC9UQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-2.6.0.tgz",
+      "integrity": "sha512-JElic4Nl3JUcIMcHX6MdYRyNRUpCp4wGfybKYdiV38fYA75BrURPXs7AUfkX9ZTAbJNpEdjEH9D+Ev7aSuSiQg==",
       "requires": {
         "geotiff": "^2.0.5",
         "three": "^0.144.0",
@@ -15,18 +15,16 @@
       }
     },
     "@aics/web-3d-viewer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.3.1.tgz",
-      "integrity": "sha512-ttKBi7L3e10CdMfCJ4KAR4SwF0YrjqYTxWVEiKGUFeZMoOu9tRcvuVd5Z74sDegEdRb3kj2G9vDsiNFzmpGJvw==",
+      "version": "2.3.3-dev.0",
+      "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.3.3-dev.0.tgz",
+      "integrity": "sha512-ruNRkjUDPnMO04N6m/d5JO6XRs80ga3tSqz6jaMD4EQ7MQcZaDlZFbU08kpqa2UMBvJuBa3ADeMGfLtWJmHtvw==",
       "requires": {
-        "@aics/volume-viewer": "^2.5.1",
-        "classnames": "^2.2.5",
+        "@aics/volume-viewer": "^2.6.0",
         "color-string": "^1.5.3",
         "d3": "^4.11.0",
         "lodash": "^4.17.20",
         "nouislider-react": "^3.4.0",
-        "react-color": "^2.13.8",
-        "react-numeric-input": "^2.2.3"
+        "react-color": "^2.13.8"
       }
     },
     "@ampproject/remapping": {
@@ -4886,7 +4884,7 @@
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
       "dev": true,
       "optional": true
     },
@@ -6712,6 +6710,38 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "prefix-css-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prefix-css-loader/-/prefix-css-loader-1.0.0.tgz",
+      "integrity": "sha512-I1K5IkoZKZ/lFM2hXcAU6vy+kuYkauICK2JqHh1bcWfuo76WaiGuX5hGM7NYqsXvjjSV7cGDS5OoRyT7CZ5b9w==",
+      "dev": true,
+      "requires": {
+        "css": "^3.0.0"
+      },
+      "dependencies": {
+        "css": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.6.0"
+          }
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6800,7 +6830,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
       "optional": true
     },
@@ -7436,11 +7466,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
-    "react-numeric-input": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-numeric-input/-/react-numeric-input-2.2.3.tgz",
-      "integrity": "sha512-0hDXY8eznhTNMYfmeXRo/R1Fyx//ub0C/tpXbIeEaTnG72P95MGGMvJbiX5i+mnmiFVT6OCgIR33mke45nNZzQ=="
-    },
     "react-slick": {
       "version": "0.25.2",
       "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.25.2.tgz",
@@ -7700,7 +7725,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/js/package.json
+++ b/js/package.json
@@ -73,7 +73,7 @@
     "react-dom": "^16.13.1"
   },
   "dependencies": {
-    "@aics/web-3d-viewer": "^2.3.3-dev.0",
+    "@aics/web-3d-viewer": "^2.3.3",
     "@jupyter-widgets/base": "^6.0.1",
     "antd": "^3.20.7",
     "chokidar": "^3.4.1",

--- a/js/package.json
+++ b/js/package.json
@@ -43,6 +43,9 @@
     },
     "webpackConfig": "./webpack.prebuilt.config.js"
   },
+  "resolutions": {
+    "@types/react": "^16"
+  },
   "devDependencies": {
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.15.6",
@@ -55,6 +58,7 @@
     "less": "^4.1.1",
     "less-loader": "^11.0.0",
     "npm-run-all": "^4.1.5",
+    "prefix-css-loader": "^1.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "resolve-url-loader": "^3.1.4",
@@ -69,7 +73,7 @@
     "react-dom": "^16.13.1"
   },
   "dependencies": {
-    "@aics/web-3d-viewer": "^2.3.1",
+    "@aics/web-3d-viewer": "^2.3.3-dev.0",
     "@jupyter-widgets/base": "^6.0.1",
     "antd": "^3.20.7",
     "chokidar": "^3.4.1",

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -38,12 +38,14 @@ export class VolumeWidgetView extends widgets.DOMWidgetView {
           rawData: volume,
           rawDims: dimensions,
           viewerChannelSettings: {
+            maskChannelName: "",
             groups: [
               {
                 name: "Channels",
-                channels: dimensions.channel_names.map((name, index) => {
-                  return { match: name, enabled: index < 3 };
-                }),
+                channels: dimensions.channel_names.map((name: string, index: number) => ({
+                  match: name,
+                  enabled: index < 3,
+                })),
               },
             ],
           },

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -38,7 +38,6 @@ export class VolumeWidgetView extends widgets.DOMWidgetView {
           rawData: volume,
           rawDims: dimensions,
           viewerChannelSettings: {
-            maskChannelName: "",
             groups: [
               {
                 name: "Channels",
@@ -49,7 +48,6 @@ export class VolumeWidgetView extends widgets.DOMWidgetView {
               },
             ],
           },
-          maskChannelName: "",
           appHeight: "400px",
           cellId: "",
           cellPath: "",

--- a/js/src/style.less
+++ b/js/src/style.less
@@ -1,3 +1,16 @@
-@import "~antd/dist/antd.less";                 // add ant styles
-@import "~antd/es/style/themes/default.less";   // apply default theme
-@import "./styles/ant-vars.less";               // ...and override with our own theming
+@import "~antd/dist/antd.less"; // add ant styles
+@import "~antd/es/style/themes/default.less"; // apply default theme
+@import "./styles/ant-vars.less"; // ...and override with our own theming
+
+.cell-viewer {
+  // Style prefixing means antd's body rules don't get applied.
+  // This is great! It means antd doesn't mess with the look of notebooks!
+  // But the app still depends on those styles to look right, so they're duplicated below.
+  color: #bfbfbf;
+  font-size: 14px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei",
+    "Helvetica Neue", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-variant: tabular-nums;
+  line-height: 1.5;
+  font-feature-settings: "tnum";
+}

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -51,6 +51,17 @@ const rules = [
         },
       },
       {
+        // Prefix antd's global styles to keep them from interfering with notebook styling
+        loader: "prefix-css-loader",
+        options: {
+          // selectors inside :where do not affect specificity - i.e. prefixed rules will not be reordered in priority.
+          // NOTE: :where was broadly supported by browsers only after ~Jan 2021
+          selector: ":where(.cell-viewer)",
+          exclude: /[.#]/, // Only prefix selectors that refer only to tags
+          minify: false,
+        },
+      },
+      {
         loader: "less-loader",
         options: {
           lessOptions: {

--- a/js/webpack.prebuilt.config.js
+++ b/js/webpack.prebuilt.config.js
@@ -12,6 +12,17 @@ const rules = [
         },
       },
       {
+        // Prefix antd's global styles to keep them from interfering with notebook styling
+        loader: "prefix-css-loader",
+        options: {
+          // selectors inside :where do not affect specificity - i.e. prefixed rules will not be reordered in priority.
+          // NOTE: :where was broadly supported by browsers only after ~Jan 2021
+          selector: ":where(.cell-viewer)",
+          exclude: /[.#]/, // Only prefix selectors that refer only to tags
+          minify: false,
+        },
+      },
+      {
         loader: "less-loader",
         options: {
           lessOptions: {


### PR DESCRIPTION
## Problem

Because antd is designed to be used as a global design solution, it modifies a lot of global styles. This messes with the styles of any web app that embeds a component built with ant - like Jupyter lab.

## Solution

Add [prefix-css-selector](https://www.npmjs.com/package/prefix-css-loader/v/1.0.0) to narrow global selectors on build so that they only apply to this extension.

Also, update viewer version to get new icons, and fix one or two associated type errors.